### PR TITLE
Update download links of Roma desktop to version 1.2.1

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -85,14 +85,14 @@
         <p class="desktop__description">The Roma Desktop Application allows you to stay connected without opening a web browser. It features notifications, real time updates, useful shortcuts, and more!</p>
         <ul class="desktop__downloads">
           <li class="downloads__item">
-            <a href="https://github.com/roma-apps/roma-desktop/releases/download/v1.2.0/Roma-1.2.0-darwin-x64.dmg" rel="noreferrer nofollow" class="button downloads__button downloads__button--mac">
+            <a href="https://github.com/roma-apps/roma-desktop/releases/download/v1.2.1/Roma-1.2.1-darwin-x64.dmg" rel="noreferrer nofollow" class="button downloads__button downloads__button--mac">
               {{ $img := resources.Get "img/apple.png" }}
               <img src="{{ $img.Permalink }}" aria-hidden="true" class="button__icon"/>
               <p class="button__description">Download for Mac</p>
             </a>
           </li>
           <li class="downloads__item">
-            <a href="https://github.com/roma-apps/roma-desktop/releases/download/v1.2.0/Roma-1.2.0-windows-x64.exe" rel="noreferrer nofollow" class="button downloads__button downloads__button--windows">
+            <a href="https://github.com/roma-apps/roma-desktop/releases/download/v1.2.1/Roma-1.2.1-windows-x64.exe" rel="noreferrer nofollow" class="button downloads__button downloads__button--windows">
              {{ $img := resources.Get "img/windows.png" }}
               <img src="{{ $img.Permalink }}" aria-hidden="true" class="button__icon"/>
               <p class="button__description">Download for Windows</p>


### PR DESCRIPTION
I released Roma [1.2.1](https://github.com/roma-apps/roma-desktop/releases/tag/v1.2.1). So I update download links to version 1.2.1.