### PR TITLE
Update download links of version 1.2.2

### DIFF
--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -177,7 +177,7 @@
     list-style: none;
     margin: 1.5rem 0;
     padding: 0;
-    max-width: 580px;
+    max-width: 925px;
   }
 
   .downloads__item,
@@ -211,6 +211,12 @@
       background-color: #ffad00;
       box-shadow: 0 5px 40px 0 rgba(255,173,0,.3);
       width: 295px;
+    }
+
+    &.downloads__button--linux {
+      background-color: #6cd33d;
+      box-shadow: 0 5px 40px 0 rgba(108,211,61,.3);
+      width: 345px;
     }
 
     @include media-query-max(700px) {
@@ -259,7 +265,7 @@
     @extend %items-center;
 
     grid-gap: 1.1rem;
-    grid-template-areas: 
+    grid-template-areas:
     'first last message message'
     'email email message message'
     'subject subject message message'
@@ -269,7 +275,7 @@
     max-width: 917px;
 
     @include media-query-max(930px) {
-      grid-template-areas: 
+      grid-template-areas:
       'first'
       'last'
       'email'

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -98,6 +98,11 @@
               <p class="button__description">Download for Windows</p>
             </a>
           </li>
+          <li class="downloads__item">
+            <a href="https://github.com/roma-apps/roma-desktop/releases/tag/v1.2.2" rel="noreferrer nofollow" class="button downloads__button downloads__button--linux">
+              <p class="button__description">Download for Linux and other OS</p>
+            </a>
+          </li>
         </ul>
         {{ $sswebp := resources.Get "img/desktop.webp" }}
         {{ $ssimg := resources.Get "img/desktop.jpg" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -85,14 +85,14 @@
         <p class="desktop__description">The Roma Desktop Application allows you to stay connected without opening a web browser. It features notifications, real time updates, useful shortcuts, and more!</p>
         <ul class="desktop__downloads">
           <li class="downloads__item">
-            <a href="https://github.com/roma-apps/roma-desktop/releases/download/v1.2.0/Roma-1.2.0-darwin-x64.dmg" rel="noreferrer nofollow" class="button downloads__button downloads__button--mac">
+            <a href="https://github.com/roma-apps/roma-desktop/releases/download/v1.2.2/Roma-1.2.2-darwin-x64.dmg" rel="noreferrer nofollow" class="button downloads__button downloads__button--mac">
               {{ $img := resources.Get "img/apple.png" }}
               <img src="{{ $img.Permalink }}" aria-hidden="true" class="button__icon"/>
               <p class="button__description">Download for Mac</p>
             </a>
           </li>
           <li class="downloads__item">
-            <a href="https://github.com/roma-apps/roma-desktop/releases/download/v1.2.0/Roma-1.2.0-windows-x64.exe" rel="noreferrer nofollow" class="button downloads__button downloads__button--windows">
+            <a href="https://github.com/roma-apps/roma-desktop/releases/download/v1.2.2/Roma-1.2.2-windows-x64.exe" rel="noreferrer nofollow" class="button downloads__button downloads__button--windows">
              {{ $img := resources.Get "img/windows.png" }}
               <img src="{{ $img.Permalink }}" aria-hidden="true" class="button__icon"/>
               <p class="button__description">Download for Windows</p>


### PR DESCRIPTION
I've updated download links of Roma desktop to version 1.2.2.
And I added download links of Linux version, like this:

![Screenshot from 2019-08-29 00-19-36](https://user-images.githubusercontent.com/4631959/63869313-e0a9be00-c9f2-11e9-9d60-ccc55fd121d3.png)
